### PR TITLE
support multiple configs with one receiver

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ $ ./promoter --config.file=<your_file>
 Promoter 镜像上传到了 Docker Hub，你可以尝试使用下面的命令来启动服务：
 
 ```shell
-$ docker run --name promoter -d -p 8080:8080 cnych/promoter:v0.1.2
+$ docker run --name promoter -d -p 8080:8080 cnych/promoter:v0.2.4
 ```
 
 ## 配置
@@ -48,19 +48,19 @@ s3:
 
 receivers:
   - name: rcv1
-    wechat_config:
-      agent_id: <agent_id>
-      to_user: "@all"
-      message_type: markdown
-      message: '{{ template "wechat.default.message" . }}'
-    dingtalk_config:
-      message_type: markdown
-      markdown:
-        title: '{{ template "dingtalk.default.title" . }}',
-        text: '{{ template "dingtalk.default.content" . }}',
-        at:
-          atMobiles: [ "123456" ]
-          isAtAll: false
+    wechat_configs:
+      - agent_id: <agent_id>
+        to_user: "@all"
+        message_type: markdown
+        message: '{{ template "wechat.default.message" . }}'
+    dingtalk_configs:
+      - message_type: markdown
+        markdown:
+          title: '{{ template "dingtalk.default.title" . }}',
+          text: '{{ template "dingtalk.default.content" . }}',
+          at:
+            atMobiles: [ "123456" ]
+            isAtAll: false
 ```
 
 在 global 下面可以配置全局属性，比如企业微信或者钉钉的密钥，S3 下面是一个对象存储（阿里云 OSS 也可以）配置，用来保存监控图标生成的图片。

--- a/api/receiver/api.go
+++ b/api/receiver/api.go
@@ -97,8 +97,8 @@ func (api *API) Update(conf *config.Config, tmpl *template.Template) {
 	var receiverNotifier = make(map[string][]ReceiveNotifier)
 	for _, rcv := range api.config.Receivers {
 		var receiverNotifiers []ReceiveNotifier
-		if rcv.DingtalkConfig != nil {
-			notifier, err := dingtalk.New(rcv.DingtalkConfig, api.tmpl, api.logger)
+		for _, dtc := range rcv.DingtalkConfigs {
+			notifier, err := dingtalk.New(dtc, api.tmpl, api.logger)
 			if err != nil {
 				level.Error(api.logger).Log("msg", "Init dingtalk notifier", "err", err)
 				continue
@@ -108,8 +108,8 @@ func (api *API) Update(conf *config.Config, tmpl *template.Template) {
 				notifier: notifier,
 			})
 		}
-		if rcv.WechatConfig != nil {
-			notifier, err := wechat.New(rcv.WechatConfig, api.tmpl, api.logger)
+		for _, wcc := range rcv.WechatConfigs {
+			notifier, err := wechat.New(wcc, api.tmpl, api.logger)
 			if err != nil {
 				level.Error(api.logger).Log("msg", "Init wechat notifier", "err", err)
 				continue

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -15,16 +15,16 @@ s3:
 
 receivers:
   - name: rcv1
-    wechat_config:
-      agent_id: <agent_id>
-      to_user: "@all"
-      message_type: markdown
-      message: '{{ template "wechat.default.message" . }}'
-    dingtalk_config:
-      message_type: markdown
-      markdown:
-        title: '{{ template "dingtalk.default.title" . }}'
-        text: '{{ template "dingtalk.default.content" . }}'
-        at:
-          atMobiles: [ "123456" ]
-          isAtAll: false
+    wechat_configs:
+      - agent_id: <agent_id>
+        to_user: "@all"
+        message_type: markdown
+        message: '{{ template "wechat.default.message" . }}'
+    dingtalk_configs:
+      - message_type: markdown
+        markdown:
+          title: '{{ template "dingtalk.default.title" . }}'
+          text: '{{ template "dingtalk.default.content" . }}'
+          at:
+            atMobiles: [ "123456" ]
+            isAtAll: false

--- a/config/config.go
+++ b/config/config.go
@@ -205,11 +205,11 @@ func resolveFilepaths(baseDir string, cfg *Config) {
 
 	cfg.Global.HTTPConfig.SetDirectory(baseDir)
 	for _, receiver := range cfg.Receivers {
-		if receiver.WechatConfig != nil {
-			receiver.WechatConfig.HTTPConfig.SetDirectory(baseDir)
+		for _, cfg := range receiver.WechatConfigs {
+			cfg.HTTPConfig.SetDirectory(baseDir)
 		}
-		if receiver.DingtalkConfig != nil {
-			receiver.DingtalkConfig.HTTPConfig.SetDirectory(baseDir)
+		for _, cfg := range receiver.DingtalkConfigs {
+			cfg.HTTPConfig.SetDirectory(baseDir)
 		}
 	}
 }
@@ -273,54 +273,53 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 			return fmt.Errorf("notification config name %q is not unique", rcv.Name)
 		}
 		// 循环 wechat 配置
-		if rcv.WechatConfig != nil {
-			if rcv.WechatConfig.HTTPConfig == nil {
-				rcv.WechatConfig.HTTPConfig = c.Global.HTTPConfig
+		for _, wcc := range rcv.WechatConfigs {
+			if wcc.HTTPConfig == nil {
+				wcc.HTTPConfig = c.Global.HTTPConfig
 			}
-			if rcv.WechatConfig.APIURL == nil {
+			if wcc.APIURL == nil {
 				if c.Global.WeChatAPIURL == nil {
 					return fmt.Errorf("no global Wechat URL set")
 				}
-				rcv.WechatConfig.APIURL = c.Global.WeChatAPIURL
+				wcc.APIURL = c.Global.WeChatAPIURL
 			}
-			if rcv.WechatConfig.APISecret == "" {
+			if wcc.APISecret == "" {
 				if c.Global.WeChatAPISecret == "" {
 					return fmt.Errorf("no global Wechat ApiSecret set")
 				}
-				rcv.WechatConfig.APISecret = c.Global.WeChatAPISecret
+				wcc.APISecret = c.Global.WeChatAPISecret
 			}
-			if rcv.WechatConfig.CorpID == "" {
+			if wcc.CorpID == "" {
 				if c.Global.WeChatAPICorpID == "" {
 					return fmt.Errorf("no global Wechat CorpID set")
 				}
-				rcv.WechatConfig.CorpID = c.Global.WeChatAPICorpID
+				wcc.CorpID = c.Global.WeChatAPICorpID
 			}
-			if !strings.HasSuffix(rcv.WechatConfig.APIURL.Path, "/") {
-				rcv.WechatConfig.APIURL.Path += "/"
+			if !strings.HasSuffix(wcc.APIURL.Path, "/") {
+				wcc.APIURL.Path += "/"
 			}
 		}
-
-		if rcv.DingtalkConfig != nil {
-			if rcv.DingtalkConfig.HTTPConfig == nil {
-				rcv.DingtalkConfig.HTTPConfig = c.Global.HTTPConfig
+		for _, dtc := range rcv.DingtalkConfigs {
+			if dtc.HTTPConfig == nil {
+				dtc.HTTPConfig = c.Global.HTTPConfig
 			}
-			if rcv.DingtalkConfig.APIURL == nil {
+			if dtc.APIURL == nil {
 				if c.Global.DingTalkAPIURL == nil {
 					return fmt.Errorf("no global Dingtalk URL set")
 				}
-				rcv.DingtalkConfig.APIURL = c.Global.DingTalkAPIURL
+				dtc.APIURL = c.Global.DingTalkAPIURL
 			}
-			if rcv.DingtalkConfig.APISecret == "" {
+			if dtc.APISecret == "" {
 				if c.Global.DingTalkAPISecret == "" {
 					return fmt.Errorf("no global Dingtalk ApiSecret set")
 				}
-				rcv.DingtalkConfig.APISecret = c.Global.DingTalkAPISecret
+				dtc.APISecret = c.Global.DingTalkAPISecret
 			}
-			if rcv.DingtalkConfig.APIToken == "" {
+			if dtc.APIToken == "" {
 				if c.Global.DingTalkAPIToken == "" {
 					return fmt.Errorf("no global Dingtalk ApiToken set")
 				}
-				rcv.DingtalkConfig.APIToken = c.Global.DingTalkAPIToken
+				dtc.APIToken = c.Global.DingTalkAPIToken
 			}
 		}
 
@@ -461,8 +460,8 @@ type Receiver struct {
 	Name string `yaml:"name" json:"name"`
 
 	//EmailConfigs     []*EmailConfig     `yaml:"email_configs,omitempty" json:"email_configs,omitempty"`
-	WechatConfig   *WechatConfig   `yaml:"wechat_config,omitempty" json:"wechat_config,omitempty"`
-	DingtalkConfig *DingtalkConfig `yaml:"dingtalk_config,omitempty" json:"dingtalk_config,omitempty"`
+	WechatConfigs   []*WechatConfig   `yaml:"wechat_configs,omitempty" json:"wechat_configs,omitempty"`
+	DingtalkConfigs []*DingtalkConfig `yaml:"dingtalk_configs,omitempty" json:"dingtalk_configs,omitempty"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface for Receiver.

--- a/deploy/kubernetes/promoter.yaml
+++ b/deploy/kubernetes/promoter.yaml
@@ -22,19 +22,19 @@ data:
 
     receivers:
       - name: rcv1
-        wechat_config:
-          agent_id: <agent_id>
-          to_user: "@all"
-          message_type: markdown
-          message: '{{ template "wechat.default.message" . }}'
-        dingtalk_config:
-          message_type: markdown
-          markdown:
-            title: '{{ template "dingtalk.default.title" . }}',
-            text: '{{ template "dingtalk.default.content" . }}',
-            at:
-              atMobiles: [ "123456" ]
-              isAtAll: false
+        wechat_configs:
+          - agent_id: <agent_id>
+            to_user: "@all"
+            message_type: markdown
+            message: '{{ template "wechat.default.message" . }}'
+        dingtalk_configs:
+          - message_type: markdown
+            markdown:
+              title: '{{ template "dingtalk.default.title" . }}',
+              text: '{{ template "dingtalk.default.content" . }}',
+              at:
+                atMobiles: [ "123456" ]
+                isAtAll: false
 
 ---
 apiVersion: apps/v1


### PR DESCRIPTION
support multiple configs with one receiver, for example below configs
wechat config change to wechat_configs array
dingtalk config change to dingtalk_configs array.

```yaml
receivers:
  - name: rcv1
    wechat_configs:
      - agent_id: <agent_id>
        to_user: "@all"
        message_type: markdown
    dingtalk_configs:
      - message_type: markdown
```